### PR TITLE
ci: add conventional commit lint for PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary

- Add `amannn/action-semantic-pull-request` GitHub Action to enforce conventional commit format on PR titles
- Since we use squash merges, the PR title becomes the commit message on main — this ensures release-please can always parse it

## Test plan

- [x] Open a PR with a non-conventional title (e.g. "Fix stuff") — should fail the check
- [ ] Open a PR with a conventional title (e.g. "fix: resolve login bug") — should pass