### PR TITLE
ci: use RELEASE_PAT for release-please and enable auto-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,13 @@ jobs:
     steps:
       - id: rp
         uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
       - name: Auto-merge release PR
         if: steps.rp.outputs.pr
-        run: gh pr merge ${{ fromJSON(steps.rp.outputs.pr).number }} --squash --admin --repo ${{ github.repository }}
+        run: gh pr merge ${{ fromJSON(steps.rp.outputs.pr).number }} --squash --auto --repo ${{ github.repository }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
 
   goreleaser:
     name: GoReleaser

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,23 @@ make test     # go test ./...
 make lint     # golangci-lint
 ```
 
+## Commit & PR title format
+
+Conventional Commits required for both commits and PR titles (PR titles become squash merge commits).
+
+Format: `<type>[(<scope>)]: #<issue> <description>`
+
+- **Scope** is optional but preferred — use the module name (`auth`, `pr`, `repo`, `pipeline`, `api`, `config`)
+- **Issue number** is required — always create an issue first if one doesn't exist
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+
+Examples:
+- `feat(auth): #7 add spinner to login flow`
+- `fix(pr): #12 handle empty reviewer list`
+- `docs: #15 add shell completions to README`
+- `ci: #16 add PR title lint workflow`
+
 ## Conventions
 
 - Don't add Co-Authored-By to commits
@@ -57,5 +74,5 @@ make lint     # golangci-lint
 ## When modifying commands
 
 - Update `docs/commands.md` if flags or behavior change
-- Update `docs/bb-ai-skills.md` if new workflows are added
+- Update `docs/bb-skill.md` if new workflows are added
 - The `bb reference` command auto-generates from command definitions — no manual update needed


### PR DESCRIPTION
## Summary

- Switch release-please to use `RELEASE_PAT` so PRs it creates trigger CI workflows (fixes checks not running on release PRs)
- Replace `--admin` with `--auto` on merge so it waits for all checks to pass before merging
- Update CLAUDE.md with commit/PR title format conventions and fix stale `docs/bb-ai-skills.md` reference

## Test plan

- [x] Push to main triggers release-please with the PAT
- [x] Release PR triggers CI checks
- [x] Auto-merge waits for checks to pass before merging