### PR TITLE
refactor(auth): #32 restyle login form with lipgloss info box

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -60,7 +60,7 @@ func newCmdLogin() *cli.Command {
 				box := lipgloss.NewStyle().
 					Width(50).
 					BorderStyle(lipgloss.RoundedBorder()).
-					BorderForeground(lipgloss.Color("#0052CC")).
+					BorderForeground(output.BitbucketBlue).
 					Padding(1, 2).
 					Render("bb has no backend or servers — all requests go directly to the Bitbucket API and your credentials never leave your device.")
 				fmt.Fprintln(f.IOOut, box)

--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -5,8 +5,10 @@ import (
 )
 
 var (
+	// BitbucketBlue is the standard Bitbucket brand color.
+	BitbucketBlue = lipgloss.Color("#0052CC")
 	// Bitbucket blue
-	Blue = lipgloss.NewStyle().Foreground(lipgloss.Color("#0052CC"))
+	Blue = lipgloss.NewStyle().Foreground(BitbucketBlue)
 	// Status colors
 	Green   = lipgloss.NewStyle().Foreground(lipgloss.Color("#36B37E"))
 	Red     = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5630"))
@@ -14,7 +16,7 @@ var (
 	Cyan    = lipgloss.NewStyle().Foreground(lipgloss.Color("#00B8D9"))
 	Muted   = lipgloss.NewStyle().Foreground(lipgloss.Color("#97A0AF"))
 	Bold    = lipgloss.NewStyle().Bold(true)
-	Header  = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0052CC"))
+	Header  = lipgloss.NewStyle().Bold(true).Foreground(BitbucketBlue)
 	Success = Green
 	Error   = Red
 	Warning = Yellow

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -27,7 +27,7 @@ func RenderTable(headers []string, rows [][]string) {
 		}
 	}
 
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#0052CC"))
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(BitbucketBlue)
 	cellStyle := lipgloss.NewStyle()
 
 	// Render header


### PR DESCRIPTION
## Summary

- Add lipgloss-styled info box (rounded border, Bitbucket blue) above the auth method picker
- Remove `.Description()` from huh select for a cleaner prompt
- Shorten API token option label

Closes #32

## Test plan

- [x] `bb auth login` — styled box appears above clean select
- [x] `bb auth login --web` — box is skipped (non-interactive path)
- [x] `bb auth login --api-token` — box is skipped (non-interactive path)