### PR TITLE
feat: #34 add repo URL to version output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ func versionString() string {
 	}
 	if Version != "dev" && !strings.HasSuffix(Version, "-dev") && strings.Contains(Version, ".") {
 		s += fmt.Sprintf("\nhttps://github.com/tyrantkhan/bitbucket-cli/releases/tag/v%s", Version)
+		s += "\nhttps://github.com/tyrantkhan/bitbucket-cli"
 	}
 	return s
 }


### PR DESCRIPTION
## Summary

- Fix version URL to use correct `bitbucket-cli` repo name
- Add repo URL to version output

Test PR to verify release-please picks up both `feat` and `fix` commits from squash merge body.

Closes #34