### PR TITLE
feat: #37 test release-please without bullet prefix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,7 @@ func NewRootCommand() *cli.Command {
 			if os.Getenv("BB_NO_UPDATE_NOTIFIER") == "1" {
 				return nil
 			}
+			// Check for newer versions in the background-safe After hook.
 			latest, err := update.CheckForUpdate(Version)
 			if err != nil {
 				return nil //nolint:nilerr // update check failures are non-fatal


### PR DESCRIPTION
## Summary

Test PR to verify release-please parses multiple conventional commits when `*` bullets are manually removed from the squash merge body before merging.

Commits:
- `fix: #37 add inline comment to repo URL`
- `feat: #37 add comment to update check`

**Before squash merging:** edit the commit body to remove `* ` prefixes and ensure blank line separation between entries.

Closes #37